### PR TITLE
Fixing indentation for KafkaLogPath list_join

### DIFF
--- a/deployment/contrail/contrail-issu.yaml
+++ b/deployment/contrail/contrail-issu.yaml
@@ -770,10 +770,10 @@ outputs:
                   list_concat:
                     - get_attr: [ContrailBase, role_data, contrail_base_volumes]
                     - - list_join:
-                      - ':'
-                      - - {get_param: DockerContrailKafkaLogPath}
-                        - /var/log/kafka
-                        - z
+                          - ':'
+                          - - {get_param: DockerContrailKafkaLogPath}
+                            - /var/log/kafka
+                            - z
                 environment:
                   map_merge:
                     - get_attr: [ContrailBase, role_data, contrail_base_env]


### PR DESCRIPTION
The current indentation undercloud list_join is invalid at this time. It
like if list_join has no argument and this breaks the deployment.